### PR TITLE
Add compile completion event

### DIFF
--- a/sandpack-client/src/clients/node/index.ts
+++ b/sandpack-client/src/clients/node/index.ts
@@ -118,6 +118,7 @@ export class SandpackNode extends SandpackClient {
       });
 
       this.dispatch({ type: "done", compilatonError: true });
+      this.dispatch({ type: "compiled" });
     }
   }
 
@@ -237,6 +238,7 @@ export class SandpackNode extends SandpackClient {
   private dispatchDoneMessage(): void {
     this.status = "done";
     this.dispatch({ type: "done", compilatonError: false });
+    this.dispatch({ type: "compiled" });
 
     if (this.iframePreviewUrl) {
       this.dispatch({

--- a/sandpack-client/src/clients/node/types.ts
+++ b/sandpack-client/src/clients/node/types.ts
@@ -14,7 +14,8 @@ type SandpackStandartMessages =
   | {
       type: "done";
       compilatonError: boolean;
-    };
+    }
+  | { type: "compiled" };
 
 type SandpackBundlerMessages =
   | {

--- a/sandpack-client/src/clients/runtime/index.ts
+++ b/sandpack-client/src/clients/runtime/index.ts
@@ -145,6 +145,10 @@ export class SandpackRuntime extends SandpackClient {
             this.status = "done";
             break;
           }
+          case "compiled": {
+            this.status = "done";
+            break;
+          }
           case "state": {
             this.bundlerState = mes.state;
             break;

--- a/sandpack-client/src/clients/runtime/types.ts
+++ b/sandpack-client/src/clients/runtime/types.ts
@@ -46,6 +46,7 @@ export type SandpackRuntimeMessage = BaseSandpackMessage &
         type: "done";
         compilatonError: boolean;
       }
+    | { type: "compiled" }
     | {
         type: "urlchange";
         url: string;

--- a/sandpack-client/src/clients/static/index.ts
+++ b/sandpack-client/src/clients/static/index.ts
@@ -196,6 +196,7 @@ export class SandpackStatic extends SandpackClient {
 
     this.status = "done";
     this.dispatch({ type: "done", compilatonError: false });
+    this.dispatch({ type: "compiled" });
     this.dispatch({
       type: "urlchange",
       url: previewUrl,


### PR DESCRIPTION
## Summary
- dispatch a new `compiled` event when the bundler finishes
- recognise the `compiled` message in the runtime client

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------