### PR TITLE
Fix build script to use pnpm

### DIFF
--- a/sandpack-react/package.json
+++ b/sandpack-react/package.json
@@ -34,11 +34,11 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "prebuild": "yarn run clean",
+    "prebuild": "pnpm run clean",
     "test": "TEST_ENV=true jest . --transformIgnorePatterns \"node_modules/(?!@codemirror)/\" --modulePathIgnorePatterns \"e2e\"",
     "lint": "eslint '**/*.ts?(x)' --fix",
     "build": "rollup -c",
-    "build:publish": "yarn build",
+    "build:publish": "pnpm run build",
     "dev": "storybook dev -p 6006 --quiet",
     "typecheck": "tsc",
     "format": "prettier --write '**/*.{ts,tsx,js,jsx}'",


### PR DESCRIPTION
## Summary
- fix `prebuild` and `build:publish` scripts in `sandpack-react/package.json` to use pnpm

## Testing
- `pnpm run build` in `sandpack-react`

------
https://chatgpt.com/codex/tasks/task_e_6856132b60808331816a6040c222fd30